### PR TITLE
84 additon: nearly no warnings

### DIFF
--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -30,7 +30,10 @@
 ;;; Code:
 
 (require 'plstore)
-(require 'mastodon-client nil t)
+
+(declare-function mastodon-client "mastodon-client")
+(declare-function mastodon-http--post "mastodon-http")
+(defvar mastodon-instance-url)
 
 (defgroup mastodon-auth nil
   "Authenticate with Mastodon."

--- a/lisp/mastodon-client.el
+++ b/lisp/mastodon-client.el
@@ -30,14 +30,16 @@
 ;;; Code:
 
 (require 'plstore)
-(require 'mastodon-http nil t)
+(declare-function mastodon-http--api "mastodon-http")
+(declare-function mastodon-http--post "mastodon-http")
 
-(defgroup mastodon-client nil
-  "Register your client with Mastodon."
-  :prefix "mastodon-client-"
-  :group 'mastodon)
 
-(defvar mastodon-client nil
+(defcustom mastodon-client--token-file (concat user-emacs-directory "mastodon.plstore")
+  "File path where Mastodon access tokens are stored."
+  :group 'mastodon
+  :type 'file)
+
+(defvar mastodon-client--client-details nil
   "Client id and secret.")
 
 (defun mastodon-client--register ()
@@ -62,11 +64,11 @@
       (json-read-from-string json-string))))
 
 (defun mastodon-client--token-file ()
-  "Return `mastodon-token-file'."
-  mastodon-token-file)
+  "Return `mastodon-client--token-file'."
+  mastodon-client--token-file)
 
 (defun mastodon-client--store ()
-  "Store client_id and client_secret in `mastodon-token-file'.
+  "Store client_id and client_secret in `mastodon-client--token-file'.
 
 Make `mastodon-client--fetch' call to determine client values."
   (let ((plstore (plstore-open (mastodon-client--token-file)))
@@ -77,19 +79,19 @@ Make `mastodon-client--fetch' call to determine client values."
     client))
 
 (defun mastodon-client--read ()
-  "Retrieve client_id and client_secret from `mastodon-token-file'."
+  "Retrieve client_id and client_secret from `mastodon-client--token-file'."
   (let* ((plstore (plstore-open (mastodon-client--token-file)))
          (mastodon (plstore-get plstore "mastodon")))
     (when mastodon
       (delete "mastodon" mastodon))))
 
 (defun mastodon-client ()
-  "Return variable `mastodon-client' plist.
+  "Return variable `mastodon-client--client-details' plist.
 
-Read plist from `mastodon-token-file' if variable is nil.
+Read plist from `mastodon-client--token-file' if variable is nil.
 Fetch and store plist if `mastodon-client--read' returns nil."
-  (or mastodon-client
-      (setq mastodon-client
+  (or mastodon-client--client-details
+      (setq mastodon-client--client-details
             (or (mastodon-client--read)
                 (mastodon-client--store)))))
 

--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -30,15 +30,16 @@
 ;;; Code:
 
 (require 'json)
+(defvar mastodon-instance-url)
+(defvar mastodon-auth--token)
+(declare-function mastodon-auth--access-token "mastodon-auth")
 
-(defgroup mastodon-http nil
-  "HTTP requests and responses for Mastodon."
-  :prefix "mastodon-http-"
-  :group 'mastodon)
+(defvar mastodon-http--api-version "v1")
 
 (defun mastodon-http--api (endpoint)
   "Return Mastondon API URL for ENDPOINT."
-  (concat mastodon-instance-url "/api/" mastodon--api-version "/" endpoint))
+  (concat mastodon-instance-url "/api/"
+          mastodon-http--api-version "/" endpoint))
 
 (defun mastodon-http--response ()
   "Capture response buffer content as string."

--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -71,8 +71,10 @@
     (with-current-buffer buffer
       (let ((toot (mastodon-inspect--download-single-toot toot-id )))
         (mastodon-tl--toot toot)
-            (replace-regexp "\n\n\n | " "\n | " nil (point-min) (point-max))
-            (mastodon-media--inline-images)))
+        (goto-char (point-min))
+        (while (search-forward "\n\n\n | " nil t)
+          (replace-match "\n | "))
+        (mastodon-media--inline-images)))
     (switch-to-buffer-other-window buffer)
     (mastodon-mode)))
 

--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -28,8 +28,12 @@
 ;; Some tools to help inspect / debug mastodon.el
 
 ;;; Code:
-
-(require 'mastodon-tl nil t)
+(declare-function mastodon-http--api "mastodon-http")
+(declare-function mastodon-http--get-json "mastodon-http")
+(declare-function mastodon-media--inline-images "mastodon-media")
+(declare-function mastodon-mode "mastodon")
+(declare-function mastodon-tl--property "mastodon-tl")
+(declare-function mastodon-tl--toot "mastodon-tl")
 
 (defgroup mastodon-inspect nil
   "Tools to help inspect toots."

--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -32,16 +32,20 @@
 ;; required by the server and client.
 
 ;;; Code:
-(require 'mastodon-http  nil t)
-
 (defgroup mastodon-media nil
   "Inline Mastadon media."
   :prefix "mastodon-media-"
   :group 'mastodon)
 
-(defvar mastodon-media-show-avatars-p
-  (image-type-available-p 'imagemagick)
-  "A boolean value stating whether to show avatars in timelines.")
+(defcustom mastodon-media--avatar-height 30
+  "Height of the user avatar images (if shown)."
+  :group 'mastodon-media
+  :type 'integer)
+
+(defcustom mastodon-media--preview-max-height 250
+  "Max height of any media attachment preview to be shown."
+  :group 'mastodon-media
+  :type 'integer)
 
 (defvar mastodon-media--generic-avatar-data
   (base64-decode-string
@@ -121,14 +125,13 @@ BAIQCEAgAIEABAIsJVH58WqHw8FIgjUIQCAACAQgEIBAAAIBCAQgEIBAAAIBCAQgEAAEAhAIQCBA
 fKRJkmVZjAQwh78A6vCRWJE8K+8AAAAASUVORK5CYII=")
   "The PNG data for a generic 200x200 'broken image' view")
 
-(defun mastodon-media--process-image-response (status-plist marker image-options region-length image-url)
+(defun mastodon-media--process-image-response (status-plist marker image-options region-length)
   "Callback function processing the url retrieve response for URL.
 
 STATUS-PLIST is the usual plist of status events as per `url-retrieve'.
 IMAGE-OPTIONS are the precomputed options to apply to the image.
 MARKER is the marker to where the response should be visible.
 REGION-LENGTH is the length of the region that should be replaced with the image.
-IMAGE-URL is the URL that was retrieved.
 "
   (let ((url-buffer (current-buffer))
         (is-error-response-p (eq :error (car status-plist))))
@@ -164,12 +167,12 @@ MEDIA-TYPE is a symbol and either 'avatar or 'media-link."
   (let ((image-options (when (image-type-available-p 'imagemagick)
                          (cond
                           ((eq media-type 'avatar)
-                           `(:height ,mastodon-avatar-height))
+                           `(:height ,mastodon-media--avatar-height))
                           ((eq media-type 'media-link)
-                           `(:max-height ,mastodon-preview-max-height))))))
+                           `(:max-height ,mastodon-media--preview-max-height))))))
     (url-retrieve url
                   #'mastodon-media--process-image-response
-                  (list (copy-marker start) image-options region-length url))))
+                  (list (copy-marker start) image-options region-length))))
 
 (defun mastodon-media--select-next-media-line ()
   "Find coordinates of the next media to load.
@@ -225,7 +228,7 @@ not been returned."
   ;; This is what a user will see on a non-graphical display
   ;; where not showing an avatar at all is preferable.
   (let ((image-options (when (image-type-available-p 'imagemagick)
-                         `(:height ,mastodon-avatar-height))))
+                         `(:height ,mastodon-media--avatar-height))))
     (concat
      (propertize " "
                  'media-url avatar-url

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -233,7 +233,9 @@ also render the html"
 (defun mastodon-tl--timeline (toots)
   "Display each toot in TOOTS."
   (mapc 'mastodon-tl--toot toots)
-  (replace-regexp "\n\n\n | " "\n | " nil (point-min) (point-max))
+  (goto-char (point-min))
+  (while (search-forward "\n\n\n | " nil t)
+    (replace-match "\n | "))
   (mastodon-media--inline-images))
 
 (defun mastodon-tl--get-update-function (&optional buffer)

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -29,15 +29,25 @@
 
 ;;; Code:
 
-(require 'mastodon-auth nil t)
-
-(defgroup mastodon-toot nil
-  "Capture Mastodon toots."
-  :prefix "mastodon-toot-"
-  :group 'mastodon)
-
 (defvar mastodon-toot--reply-to-id nil)
 (defvar mastodon-toot--content-warning nil)
+
+(declare-function mastodon-http--api "mastodon-http")
+(declare-function mastodon-http--post "mastodon-http")
+(declare-function mastodon-http--triage "mastodon-http")
+(declare-function mastodon-tl--field "mastodon-tl")
+(declare-function mastodon-tl--goto-next-toot "mastodon-tl")
+(declare-function mastodon-tl--property "mastodon-tl")
+(declare-function mastodon-toot "mastodon")
+
+(defvar mastodon-toot-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") #'mastodon-toot--send)
+    (define-key map (kbd "C-c C-k") #'mastodon-toot--cancel)
+    (define-key map (kbd "C-c C-w") #'mastodon-toot--toggle-warning)
+      map)
+  "Keymap for `mastodon-toot'.")
+
 
 (defun mastodon-toot--action-success (marker &optional rm)
   "Insert MARKER with 'success face in byline.
@@ -210,14 +220,6 @@ If REPLY-TO-ID is provided, set the MASTODON-TOOT--REPLY-TO-ID var."
       (mastodon-toot--display-docs)
       (mastodon-toot--setup-as-reply reply-to-user reply-to-id))
     (mastodon-toot-mode t)))
-
-(defvar mastodon-toot-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-c") #'mastodon-toot--send)
-    (define-key map (kbd "C-c C-k") #'mastodon-toot--cancel)
-    (define-key map (kbd "C-c C-w") #'mastodon-toot--toggle-warning)
-      map)
-  "Keymap for `mastodon-toot'.")
 
 (define-minor-mode mastodon-toot-mode
   "Minor mode to capture Mastodon toots."

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -56,7 +56,10 @@ Remove MARKER if RM is non-nil."
   (let ((inhibit-read-only t)
         (bol (progn (move-beginning-of-line nil) (point)))
         (eol (progn (move-end-of-line nil) (point))))
-    (when rm (replace-regexp (format "(%s) " marker) "" nil bol eol))
+    (when rm
+      (goto-char bol)
+      (if (search-forward (format "(%s) " marker) eol t)
+          (replace-match "")))
     (move-beginning-of-line nil)
     (mastodon-tl--goto-next-toot)
     (unless rm

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -30,8 +30,20 @@
 ;; it is a labor of love.
 
 ;;; Code:
-
-(require 'mastodon-auth nil t)
+(declare-function discover-add-context-menu "discover")
+(declare-function emojify-mode "emojify")
+(declare-function mastodon-tl--get-federated-timeline "mastodon-tl")
+(declare-function mastodon-tl--get-home-timeline "mastodon-tl")
+(declare-function mastodon-tl--get-local-timeline "mastodon-tl")
+(declare-function mastodon-tl--get-tag-timeline "mastodon-tl")
+(declare-function mastodon-tl--goto-next-toot "mastodon-tl")
+(declare-function mastodon-tl--goto-prev-toot "mastodon-tl")
+(declare-function mastodon-tl--thread "mastodon-tl")
+(declare-function mastodon-tl--update "mastodon-tl")
+(declare-function mastodon-toot--compose-buffer "mastodon-toot")
+(declare-function mastodon-toot--reply "mastodon-toot")
+(declare-function mastodon-toot--toggle-boost "mastodon-toot")
+(declare-function mastodon-toot--toggle-favourite "mastodon-toot")
 
 (defgroup mastodon nil
   "Interface with Mastodon."
@@ -43,11 +55,6 @@
   :group 'mastodon
   :type 'string)
 
-(defcustom mastodon-token-file (concat user-emacs-directory "mastodon.plstore")
-  "File path where Mastodon access tokens are stored."
-  :group 'mastodon
-  :type 'file)
-
 (defcustom mastodon-toot-timestamp-format "%F %T"
   "Format to use for timestamps.
 
@@ -57,24 +64,9 @@ Use. e.g. \"%c\" for your locale's date and time format."
   :group 'mastodon
   :type 'string)
 
-(defcustom mastodon-avatar-height 30
-  "Height of the user avatar images (if shown)."
-  :group 'mastodon
-  :type 'integer)
-
-(defcustom mastodon-preview-max-height 250
-  "Max height of any media attachment preview to be shown."
-  :group 'mastodon
-  :type 'integer)
-
 (defvar mastodon-mode-map
   (make-sparse-keymap)
   "Keymap for `mastodon-mode'.")
-
-(defvar mastodon--api-version "v1")
-
-(defvar mastodon-buffer-spec nil
-  "A unique identifier and functions for each Mastodon buffer.")
 
 (defcustom mastodon-mode-hook nil
   "Hook run when entering Mastodon mode."
@@ -106,7 +98,6 @@ Use. e.g. \"%c\" for your locale's date and time format."
 (defun mastodon ()
   "Connect Mastodon client to `mastodon-instance-url' instance."
   (interactive)
-  (require 'mastodon-tl nil t)
   (mastodon-tl--get-home-timeline))
 
 ;;;###autoload
@@ -116,7 +107,6 @@ Use. e.g. \"%c\" for your locale's date and time format."
 If USER is non-nil, insert after @ symbol to begin new toot.
 If REPLY-TO-ID is non-nil, attach new toot to a conversation."
   (interactive)
-  (require 'mastodon-toot nil t)
   (mastodon-toot--compose-buffer user reply-to-id))
 
 ;;;###autoload

--- a/test/mastodon-client-tests.el
+++ b/test/mastodon-client-tests.el
@@ -54,22 +54,22 @@
 
 (ert-deftest client-1 ()
   "Should return `mastondon-client' if non-nil."
-  (let ((mastodon-client t))
+  (let ((mastodon-client--client-details t))
     (should (eq (mastodon-client) t))))
 
 (ert-deftest client-2 ()
   "Should read from `mastodon-token-file' if available."
-  (let ((mastodon-client nil))
+  (let ((mastodon-client--client-details nil))
     (with-mock
       (mock (mastodon-client--read) => '(:client_id "foo" :client_secret "bar"))
       (should (equal (mastodon-client) '(:client_id "foo" :client_secret "bar")))
-      (should (equal mastodon-client '(:client_id "foo" :client_secret "bar"))))))
+      (should (equal mastodon-client--client-details '(:client_id "foo" :client_secret "bar"))))))
 
 (ert-deftest client-3 ()
   "Should store client data in plstore if it can't be read."
-  (let ((mastodon-client nil))
+  (let ((mastodon-client--client-details nil))
     (with-mock
       (mock (mastodon-client--read))
       (mock (mastodon-client--store) => '(:client_id "foo" :client_secret "baz"))
       (should (equal (mastodon-client) '(:client_id "foo" :client_secret "baz")))
-      (should (equal mastodon-client '(:client_id "foo" :client_secret "baz"))))))
+      (should (equal mastodon-client--client-details '(:client_id "foo" :client_secret "baz"))))))

--- a/test/mastodon-media-tests.el
+++ b/test/mastodon-media-tests.el
@@ -6,7 +6,7 @@
     (mock (image-type-available-p 'imagemagick) => t)
     (mock (create-image * 'imagemagick t :height 123) => :mock-image)
 
-    (let* ((mastodon-avatar-height 123)
+    (let* ((mastodon-media--avatar-height 123)
            (result (mastodon-media--get-avatar-rendering "http://example.org/img.png"))
            (result-no-properties (substring-no-properties result))
            (properties (text-properties-at 0 result)))
@@ -21,7 +21,7 @@
   (with-mock
     (mock (create-image * nil t) => :mock-image)
 
-    (let* ((mastodon-preview-max-height 123)
+    (let* ((mastodon-media--preview-max-height 123)
            (result (mastodon-media--get-media-link-rendering "http://example.org/img.png"))
            (result-no-properties (substring-no-properties result))
            (properties (text-properties-at 0 result)))
@@ -34,7 +34,7 @@
 (ert-deftest mastodon-media:load-image-from-url:avatar-with-imagemagic ()
   "Should make the right call to url-retrieve."
   (let ((url "http://example.org/image.png")
-        (mastodon-avatar-height 123))
+        (mastodon-media--avatar-height 123))
     (with-mock
       (mock (image-type-available-p 'imagemagick) => t)
       (mock (create-image * 'imagemagick t :height 123) => '(image foo))
@@ -42,7 +42,7 @@
       (mock (url-retrieve
              url
              #'mastodon-media--process-image-response
-             '(:my-marker (:height 123) 1 "http://example.org/image.png"))
+             '(:my-marker (:height 123) 1))
             => :called-as-expected)
 
       (with-temp-buffer
@@ -62,7 +62,7 @@
       (mock (url-retrieve
              url
              #'mastodon-media--process-image-response
-             '(:my-marker () 1 "http://example.org/image.png"))
+             '(:my-marker () 1))
             => :called-as-expected)
 
       (with-temp-buffer
@@ -82,13 +82,13 @@
       (mock (url-retrieve
              "http://example.org/image.png"
              #'mastodon-media--process-image-response
-             '(:my-marker (:max-height 321) 5 "http://example.org/image.png"))
+             '(:my-marker (:max-height 321) 5))
             => :called-as-expected)
       (with-temp-buffer
         (insert (concat "Start:"
                         (mastodon-media--get-media-link-rendering url)
                         ":rest"))
-        (let ((mastodon-preview-max-height 321))
+        (let ((mastodon-media--preview-max-height 321))
           (should (eq :called-as-expected (mastodon-media--load-image-from-url url 'media-link 7 5))))))))
 
 (ert-deftest mastodon-media:load-image-from-url:media-link-without-imagemagic ()
@@ -101,14 +101,14 @@
       (mock (url-retrieve
              "http://example.org/image.png"
              #'mastodon-media--process-image-response
-             '(:my-marker () 5 "http://example.org/image.png"))
+             '(:my-marker () 5))
             => :called-as-expected)
 
       (with-temp-buffer
         (insert (concat "Start:"
                         (mastodon-media--get-avatar-rendering url)
                         ":rest"))
-        (let ((mastodon-preview-max-height 321))
+        (let ((mastodon-media--preview-max-height 321))
           (should (eq :called-as-expected (mastodon-media--load-image-from-url url 'media-link 7 5))))))))
 
 (ert-deftest mastodon-media:process-image-response ()
@@ -134,7 +134,7 @@
 
          (mock (create-image "fake\nimage\ndata" 'imagemagick t ':image :option) => :fake-image)
 
-         (mastodon-media--process-image-response () used-marker '(:image :option) 1 "the-url")
+         (mastodon-media--process-image-response () used-marker '(:image :option) 1)
 
          ;; the used marker has been unset:
          (should (null (marker-position used-marker)))

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -105,7 +105,7 @@
 
 (ert-deftest mastodon-tl--byline-regular ()
   "Should format the regular toot correctly."
-  (let ((mastodon-media-show-avatars-p nil)
+  (let ((mastodon-tl--show-avatars-p nil)
         (timestamp (cdr (assoc 'created_at mastodon-tl-test-base-toot))))
     (with-mock
       (mock (date-to-time timestamp) => '(22782 21551))
@@ -119,7 +119,7 @@
 
 (ert-deftest mastodon-tl--byline-regular-with-avatar ()
   "Should format the regular toot correctly."
-  (let ((mastodon-media-show-avatars-p t)
+  (let ((mastodon-tl--show-avatars-p t)
         (timestamp (cdr (assoc 'created_at mastodon-tl-test-base-toot))))
     (with-mock
       (stub create-image => '(image "fake data"))
@@ -134,7 +134,7 @@
 
 (ert-deftest mastodon-tl--byline-boosted ()
   "Should format the boosted toot correctly."
-  (let* ((mastodon-media-show-avatars-p nil)
+  (let* ((mastodon-tl--show-avatars-p nil)
          (toot (cons '(reblogged . t) mastodon-tl-test-base-toot))
          (timestamp (cdr (assoc 'created_at toot))))
     (with-mock
@@ -148,7 +148,7 @@
 
 (ert-deftest mastodon-tl--byline-favorited ()
   "Should format the favourited toot correctly."
-  (let* ((mastodon-media-show-avatars-p nil)
+  (let* ((mastodon-tl--show-avatars-p nil)
          (toot (cons '(favourited . t) mastodon-tl-test-base-toot))
          (timestamp (cdr (assoc 'created_at toot))))
     (with-mock
@@ -163,7 +163,7 @@
 
 (ert-deftest mastodon-tl--byline-boosted/favorited ()
   "Should format the boosted & favourited toot correctly."
-  (let* ((mastodon-media-show-avatars-p nil)
+  (let* ((mastodon-tl--show-avatars-p nil)
          (toot `((favourited . t) (reblogged . t) ,@mastodon-tl-test-base-toot))
          (timestamp (cdr (assoc 'created_at toot))))
     (with-mock
@@ -177,7 +177,7 @@
 
 (ert-deftest mastodon-tl--byline-reblogged ()
   "Should format the reblogged toot correctly."
-  (let* ((mastodon-media-show-avatars-p nil)
+  (let* ((mastodon-tl--show-avatars-p nil)
          (toot mastodon-tl-test-base-boosted-toot)
          (original-toot (cdr (assoc 'reblog mastodon-tl-test-base-boosted-toot)))
          (timestamp (cdr (assoc 'created_at toot)))
@@ -197,7 +197,7 @@
 
 (ert-deftest mastodon-tl--byline-reblogged-with-avatars ()
   "Should format the reblogged toot correctly."
-  (let* ((mastodon-media-show-avatars-p t)
+  (let* ((mastodon-tl--show-avatars-p t)
          (toot mastodon-tl-test-base-boosted-toot)
          (original-toot (cdr (assoc 'reblog mastodon-tl-test-base-boosted-toot)))
          (timestamp (cdr (assoc 'created_at toot)))
@@ -218,7 +218,7 @@
 
 (ert-deftest mastodon-tl--byline-reblogged-boosted/favorited ()
   "Should format the reblogged toot that was also boosted & favoritedcorrectly."
-  (let* ((mastodon-media-show-avatars-p nil)
+  (let* ((mastodon-tl--show-avatars-p nil)
          (toot `((favourited . t) (reblogged . t) ,@mastodon-tl-test-base-boosted-toot))
          (original-toot (cdr (assoc 'reblog mastodon-tl-test-base-boosted-toot)))
          (timestamp (cdr (assoc 'created_at toot)))


### PR DESCRIPTION
We do this by
- moving vars into the files where they are (mostly) used
- "declaring" vars used elsewhere with the (`defvar <var-name>`) pattern,
- declaring functions defined in others functions rather than loading the file via `require`,
- replacing uses of `replace-regexp` with `search-forward` and `replace-match`.
